### PR TITLE
added an in-app browser option to open links in SVC

### DIFF
--- a/ProtonMail/ProtonMail/Base.lproj/Localizable.strings
+++ b/ProtonMail/ProtonMail/Base.lproj/Localizable.strings
@@ -294,6 +294,8 @@
 "Mobile Signature" = "Mobile signature";
 "Auto Show Images" = "Auto show images";
 
+"In-app browser" = "In-app browser";
+
 "Swipe Left to Right" = "Swipe Left to Right";
 "Swipe Right to Left" = "Swipe Right to Left";
 "Change left swipe action" = "Change left swipe action";

--- a/ProtonMail/ProtonMail/Controller/Message Detail/LinkOpener.swift
+++ b/ProtonMail/ProtonMail/Controller/Message Detail/LinkOpener.swift
@@ -24,11 +24,11 @@
 import Foundation
 
 enum LinkOpener: String, CaseIterable {
-    case safari, chrome, firefox, firefoxFocus, operaMini, operaTouch, brave, edge, yandex, duckDuckGo, onion
-    
+    case safari, inAppBrowser, chrome, firefox, firefoxFocus, operaMini, operaTouch, brave, edge, yandex, duckDuckGo, onion
+
     private var scheme: String {
         switch self {
-        case .safari: return "https" // default case
+        case .safari, .inAppBrowser: return "https" // default case
         case .chrome: return "googlechrome"
         case .firefox: return "firefox"
         case .firefoxFocus: return "firefox-focus"
@@ -45,6 +45,7 @@ enum LinkOpener: String, CaseIterable {
     var title: String {
         switch self {
         case .safari: return "Safari"
+        case .inAppBrowser: return LocalString._in_app_browser
         case .chrome: return "Chrome"
         case .firefox: return "Firefox"
         case .firefoxFocus: return "Firefox Focus"
@@ -111,7 +112,7 @@ enum LinkOpener: String, CaseIterable {
         case .duckDuckGo:
             return URL(string: "ddgQuickLink://\(url)")
             
-        case .safari:
+        case .safari, .inAppBrowser:
             return url
         }
         

--- a/ProtonMail/ProtonMail/Controller/Message Detail/Modern/Body/MessageBodyCoordinator.swift
+++ b/ProtonMail/ProtonMail/Controller/Message Detail/Modern/Body/MessageBodyCoordinator.swift
@@ -22,6 +22,7 @@
     
 
 import Foundation
+import SafariServices
 
 class MessageBodyCoordinator {
     private weak var controller: MessageBodyViewController!
@@ -35,15 +36,20 @@ class MessageBodyCoordinator {
     }
     
     internal func open(url originalURL: URL) {
-        if let url = userCachedStatus.browser.deeplink(to: originalURL),
-            UIApplication.shared.canOpenURL(url)
-        {
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
-            return
+        if userCachedStatus.browser == .inAppBrowser {
+            let safari = SFSafariViewController(url: originalURL)
+            controller.present(safari, animated: true)
+        } else {
+            var urlToOpen = originalURL
+
+            if let customSchemeURL = userCachedStatus.browser.deeplink(to: originalURL),
+                UIApplication.shared.canOpenURL(customSchemeURL)
+            {
+                urlToOpen = customSchemeURL
+            }
+
+            UIApplication.shared.open(urlToOpen, options: [:], completionHandler: nil)
         }
-        
-        // fallback to Safari if there are any problems
-        UIApplication.shared.open(originalURL, options: [:], completionHandler: nil)
     }
     
     internal func mail(to url: URL) {

--- a/ProtonMail/ProtonMail/en.lproj/Localizable.strings
+++ b/ProtonMail/ProtonMail/en.lproj/Localizable.strings
@@ -295,6 +295,8 @@
 "Mobile Signature" = "Mobile signature";
 "Auto Show Images" = "Auto show images";
 
+"In-app browser" = "In-app browser";
+
 "Swipe Left to Right" = "Swipe Left to Right";
 "Swipe Right to Left" = "Swipe Right to Left";
 "Change left swipe action" = "Change left swipe action";

--- a/ProtonMail/ProtonMailCommon/Constants/Localization.swift
+++ b/ProtonMail/ProtonMailCommon/Constants/Localization.swift
@@ -664,6 +664,8 @@ class LocalizedString {
     /// "Resetting message cache ..."
     lazy var _settings_resetting_cache = NSLocalizedString("Resetting message cache ...", comment: "Title")
 
+    /// "In-app browser"
+    lazy var _in_app_browser = NSLocalizedString("In-app browser", comment: "Option in browser list")
     /// "This preference will fallback to Safari if the browser of choice will be uninstalled."
     lazy var _settings_browser_disclaimer = NSLocalizedString("This preference will fallback to Safari if the browser of choice will be uninstalled.", comment: "Title")
     


### PR DESCRIPTION
This fixes a second thing that I was missing in ProtonMail from the beginning: being able to open any links from emails in an in-app browser (Safari View Controller) instead of always being redirected to the Safari app. Honestly, with just these two changes (this & easy archiving) I would probably be using this app on my iPhone much, much more than I am now.

This is implemented as a new "virtual" browser in the `LinkOpener` browser list, which is always installed. `MessageBodyCoordinator.open(url:)` adds a special case for when this option is set.

Similar caveats apply as in #4 - feel free to change the wording, design, and I'm not sure if the settings system requires any special handling for this case (although it seems to remember the setting on relaunch now - the code was simpler than in #4 because I reused an existing setting instead of adding a new property).

<p align="center"><img src="https://user-images.githubusercontent.com/28465/68429464-cf311f00-01b6-11ea-8ab4-7874fff47903.jpg" width="375"></p>
