### PR TITLE
Add support for mailto: urls

### DIFF
--- a/ProtonMail/ProtonMail/AppDelegate.swift
+++ b/ProtonMail/ProtonMail/AppDelegate.swift
@@ -272,7 +272,14 @@ extension AppDelegate: UIApplicationDelegate {
     
     @available(iOS, deprecated: 13, message: "This method will not get called on iOS 13, move the code to WindowSceneDelegate.scene(_:openURLContexts:)" )
     func application(_ application: UIApplication, handleOpen url: URL) -> Bool {
-        guard let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true), urlComponents.host == "signup" else {
+        guard let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true) else { return false; }
+
+        if urlComponents.host == "compose" {
+            coordinator.presentComposer(urlComponents.queryItems)
+            return true;
+        }
+
+        if urlComponents.host != "signup" {
             return false
         }
         

--- a/ProtonMail/ProtonMail/Controller/Mailbox/MailboxCoordinator.swift
+++ b/ProtonMail/ProtonMail/Controller/Mailbox/MailboxCoordinator.swift
@@ -146,6 +146,41 @@ class MailboxCoordinator : DefaultCoordinator {
                 return false
             }
             let viewModel = ContainableComposeViewModel(msg: nil, action: .newDraft)
+
+            // Some parsing for mailto: options. Might be better elsewhere.
+            if let composeQueryItems = sender as? [URLQueryItem] {
+                composeQueryItems.forEach { (query: URLQueryItem) in
+                    switch query.name {
+                    case "to":
+                        query.value?.components(separatedBy: ",").forEach({ (email) in
+                            let contact = ContactVO(name: "", email: email)
+                            viewModel.addToContacts(contact)
+                        })
+
+                    case "cc":
+                        query.value?.components(separatedBy: ",").forEach({ (email) in
+                            let contact = ContactVO(name: "", email: email)
+                            viewModel.addCcContacts(contact)
+                        })
+                        
+                    case "bcc":
+                        query.value?.components(separatedBy: ",").forEach({ (email) in
+                            let contact = ContactVO(name: "", email: email)
+                            viewModel.addBccContacts(contact)
+                        })
+                        
+                    case "subject":
+                        viewModel.setSubject(query.value ?? "")
+                        
+                    case "body":
+                        viewModel.setBody(query.value ?? "")
+                        
+                    default:
+                        return
+                    }
+                }
+            }
+
             next.set(viewModel: ComposeContainerViewModel(editorViewModel: viewModel))
             next.set(coordinator: ComposeContainerViewCoordinator(controller: next))
             

--- a/ProtonMail/ProtonMail/Controller/Mailbox/MailboxViewController.swift
+++ b/ProtonMail/ProtonMail/Controller/Mailbox/MailboxViewController.swift
@@ -182,6 +182,11 @@ class MailboxViewController: ProtonMailViewController, ViewModelProtocol, Coordi
         
         ///
         self.viewModel.cleanReviewItems()
+        NotificationCenter.default.addObserver(self, selector:#selector(onMailto), name: NSNotification.Name(rawValue: "HandleMailto"), object: nil)
+    }
+
+    @objc func onMailto(_ notification: Notification) {
+        coordinator?.go(to: .composer, sender: notification.userInfo?["queryItems"] ?? [])
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/ProtonMail/ProtonMail/WindowsCoordinator.swift
+++ b/ProtonMail/ProtonMail/WindowsCoordinator.swift
@@ -263,6 +263,27 @@ class WindowsCoordinator: CoordinatorNew {
         _ = deeplink.popFirst
         self.start()
     }
+
+    // Manages passing through the view heirarchy to open the Composer window and set mailto:
+    // properties. Could potentially be a bit cleaner, open to suggestions.
+    func presentComposer(_ queryItems: [URLQueryItem]?) {
+        let deeplink = DeepLink(MenuCoordinatorNew.Destination.mailbox.rawValue)
+        self.appWindow.enumerateViewControllerHierarchy { controller, stop in
+            if let menu = controller as? MenuViewController,
+                let coordinator = menu.getCoordinator() as? MenuCoordinatorNew
+            {
+                coordinator.follow(deeplink)
+                stop = true
+            }
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(2)) {
+            let notification2 = Notification(name: Notification.Name(rawValue: "HandleMailto"),
+                                        object: nil,
+                                        userInfo: ["queryItems": queryItems])
+            NotificationCenter.default.post(notification2)
+        }
+    }
 }
 
 // This logic is taken from AppDelegate as-is, not refactored


### PR DESCRIPTION
Heya,

I saw someone over on [Reddit](https://old.reddit.com/r/ProtonMail/comments/ebr1p4/add_protonmail_to_the_list_of_mail_apps_in/) asking why Protonmail doesn't support `mailto:` style links. I'd been looking to mess around with the iOS codebase and had some free time, so experimented with adding it.

From what I read on another issue you've got a refactor going on internally, so no worries if this doesn't fit right now - just wanted to throw it out there and open discussion on it. The reason something like this would be nice is that if it's supported, then Firefox on iOS could open `mailto:` links in Protonmail if the user chooses it in settings.

[I made the requisite changes in Firefox iOS already](https://github.com/ryanmcgrath/firefox-ios/commit/5eaf47a5d6a1351f8b9ead124eb3251813f1031d), could pull request them over there if/when this is deemed okay over here.

Not 100% happy about the `Dispatch` delay hack but I didn't want to muck too much with altering the internal structure. Open to comments/critiques/etc for sure.

A simple test project can be drummed up by making a blank iOS project in Xcode, whitelisting `LSApplicationQueriesSchemes` to include `protonmail`, and then dumping something like the following in `applicationDidFinishLaunching`:

``` swift
let url = URL(string: "protonmail://compose?to=ryan@venodesigns.net,ryan_fb@venodesigns.net&cc=bert@ryanmcgrath@protonmail.com&bcc=ryan@rymc.io&subject=lol&body=Hello%20thar")!

UIApplication.shared.open(url)
```

Hope it's useful!