### PR TITLE
Fix missing PersistentQueue.Key in queuedMessageIds

### DIFF
--- a/ProtonMail/ProtonMailCommon/Queue/MessageQueue.swift
+++ b/ProtonMail/ProtonMailCommon/Queue/MessageQueue.swift
@@ -71,7 +71,7 @@ class MessageQueue: PersistentQueue {
     func queuedMessageIds() -> [String] {
         let ids = self.queue.compactMap { entryOfQueue -> String? in
             guard let object = entryOfQueue as? [String: Any],
-                let element = object[Key.object] as? [String: String],
+				let element = object[PersistentQueue.Key.object] as? [String: String],
                 let id = element[Key.id] else {
                     return nil
             }


### PR DESCRIPTION
MessageQueue.Key hides the PersistentQueue.Key struct but in 

func queuedMessageIds() -> [String]

we do access the "object" element. I am not sure how this works in Xcode 11.1, but it seems a bug.
This PR adds the full qualifying name, "PersistentQueue.Key.object"
(this solves an error when building with Xcode 11.5).

I think the best solution would be to encapsulate the access to the "PersistentQueue.Key.object" inside PersistentQueue itself, but that change might be more impactful.

Test plan:

Built it successfully in Xcode 11.1 and 11.5
 