### PR TITLE
Fix multistage text input issue

### DIFF
--- a/ProtonMail/ProtonMail/ViewControllers/APP_share/Compose/HtmlEditor/HtmlEditor.js
+++ b/ProtonMail/ProtonMail/ViewControllers/APP_share/Compose/HtmlEditor/HtmlEditor.js
@@ -299,7 +299,7 @@ html_editor.editor.addEventListener("keydown", function (key) {
 
 html_editor.caret = document.createElement('caret'); // something happening here preventing selection of elements
 html_editor.getCaretYPosition = function () {
-    var range = window.getSelection().getRangeAt(0);
+    var range = window.getSelection().getRangeAt(0).cloneRange();
     range.collapse(false);
     range.insertNode(html_editor.caret);
 


### PR DESCRIPTION
<!-- General bug template -->

# Problem

Using the range before clone it will break multistage text input in iOS 17.

# Solution

Clone the range first.

# Risk

I am an iOS developer unfamiliar with JavaScript, so I am unsure if this is a perfect solution.
But it seems promising to me.

# Related Problem Report

2430943
