### PR TITLE
Fix xcbeautify repository reference in Mintfile

### DIFF
--- a/Mintfile
+++ b/Mintfile
@@ -3,5 +3,5 @@ krzysztofzablocki/Sourcery@2.2.4
 mono0926/LicensePlist@3.25.1
 realm/SwiftLint@0.55.0
 SwiftGen/SwiftGen@6.6.3
-tuist/xcbeautify@2.3.0
+cpisciotta/xcbeautify@2.3.0
 yonaskolb/xcodegen@2.40.1


### PR DESCRIPTION
As the repository reference tuist/xcbeautify
does not have tagged version 2.3.0, due to
which 'mint bootstrap' was failing.

Correct reference for xcbeautify is added.

Fixes issue #80