### PR TITLE
Cache expensive allocations and simplify collection idioms

### DIFF
--- a/Modules/App/Sources/UI/Screens/Sidebar/SidebarModel.swift
+++ b/Modules/App/Sources/UI/Screens/Sidebar/SidebarModel.swift
@@ -218,7 +218,7 @@ final class SidebarModel: Sendable, ObservableObject {
     }
 
     private func selectFirstSystemItemIfNeeded() {
-        if state.items.filter(\.isSelected).isEmpty, let first = state.system.first {
+        if !state.items.contains(where: \.isSelected), let first = state.system.first {
             select(item: .system(first))
         }
     }

--- a/Modules/App/Sources/UI/Views/MailboxItemListView/MailboxItemsListView.swift
+++ b/Modules/App/Sources/UI/Views/MailboxItemListView/MailboxItemsListView.swift
@@ -175,10 +175,11 @@ struct MailboxItemsListView<EmptyView: View, ComposeButton: ToolbarContent, Unre
     private func voiceOverValue(for item: MailboxItemCellUIModel) -> String {
         let unread = item.isRead ? "" : L10n.Mailbox.VoiceOver.unread.string
         let expiration = item.expirationDate?.toExpirationDateUIModel?.text.string ?? ""
+        let previewables = item.attachments.previewables
         let attachments =
-            item.attachments.previewables.count > 0
-            ? L10n.Mailbox.VoiceOver.attachments(count: item.attachments.previewables.count).string
-            : ""
+            previewables.isEmpty
+            ? ""
+            : L10n.Mailbox.VoiceOver.attachments(count: previewables.count).string
         let value: String = """
             \(unread)
             \(item.emails).

--- a/Modules/App/Sources/UI/Views/TrackersInfo/TrackersUIModel.swift
+++ b/Modules/App/Sources/UI/Views/TrackersInfo/TrackersUIModel.swift
@@ -36,11 +36,11 @@ struct TrackersUIModel: Identifiable, Hashable {
     }
 
     var areTrackersPresented: Bool {
-        blockedTrackers.count > 0 || (blockedTrackers.isEmpty && cleanedLinks.isEmpty)
+        !blockedTrackers.isEmpty || (blockedTrackers.isEmpty && cleanedLinks.isEmpty)
     }
 
     var areLinksPresented: Bool {
-        cleanedLinks.count > 0
+        !cleanedLinks.isEmpty
     }
 
     static var empty: TrackersUIModel {

--- a/Modules/InboxComposer/Sources/Composer/UIKitComponents/RecipientsFieldController.swift
+++ b/Modules/InboxComposer/Sources/Composer/UIKitComponents/RecipientsFieldController.swift
@@ -140,7 +140,7 @@ final class RecipientsFieldController: UIViewController {
             updateStateInExpandedAndEditingViews(state)
         case .editing:
             updateStateInExpandedAndEditingViews(state)
-            if state.recipients.filter(\.isSelected).isEmpty {
+            if !state.recipients.contains(where: \.isSelected) {
                 editingController.setFocus()
             }
         case .contactPicker:

--- a/Modules/InboxComposer/Sources/Composer/UIKitComponents/RecipientsFieldEditingController.swift
+++ b/Modules/InboxComposer/Sources/Composer/UIKitComponents/RecipientsFieldEditingController.swift
@@ -216,7 +216,7 @@ extension RecipientsFieldEditingController: UICollectionViewDataSource {
             case .onTextChanged(let text):
                 onEvent?(.onInputChange(text: text))
             case .onDeleteKeyPressedOnEmptyTextField:
-                if !cellUIModels.filter(\.isRecipient).isEmpty { removeFocusFromCursor() }
+                if cellUIModels.contains(where: \.isRecipient) { removeFocusFromCursor() }
                 onEvent?(.onDeleteKeyPressedInsideEmptyInputField)
             case .onReturnKeyPressed:
                 onEvent?(.onReturnKeyPressed)

--- a/Modules/InboxComposer/Sources/Composer/UIKitComponents/Views/DraftActionBarViewController.swift
+++ b/Modules/InboxComposer/Sources/Composer/UIKitComponents/Views/DraftActionBarViewController.swift
@@ -302,13 +302,17 @@ extension DraftActionBarViewController {
     }
 }
 
+private let customExpirationDateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    formatter.timeStyle = .short
+    return formatter
+}()
+
 private extension DraftExpirationTime {
     var customDateString: String? {
         if let customDate {
-            let formatter = DateFormatter()
-            formatter.dateStyle = .medium
-            formatter.timeStyle = .short
-            return formatter.string(from: customDate)
+            return customExpirationDateFormatter.string(from: customDate)
         }
         return nil
     }

--- a/Modules/InboxComposer/Sources/Composer/Utils/HtmlSanitizer.swift
+++ b/Modules/InboxComposer/Sources/Composer/Utils/HtmlSanitizer.swift
@@ -18,11 +18,13 @@
 import Foundation
 
 struct HtmlSanitizer {
+    private static let encoder = JSONEncoder()
+
     /// Escapes characters that can trigger WebKit JS SyntaxError
     static func applyStringLiteralEscapingRules(html: String) -> String {
         // We use JSONEncoder as a trick to ensure all problematic
         // characters (quotes, backslashes, control chars) are properly escaped.
-        let jsonEncodedText = try! JSONEncoder().encode(html)
+        let jsonEncodedText = try! encoder.encode(html)
         let sanitized = String(data: jsonEncodedText, encoding: .utf8)!
         return sanitized
     }

--- a/Modules/InboxComposer/Sources/Composer/Views/ComposerView/ComposerModel.swift
+++ b/Modules/InboxComposer/Sources/Composer/Views/ComposerView/ComposerModel.swift
@@ -621,9 +621,8 @@ extension ComposerModel {
     private func updateStateAttachmentUIModels() async {
         do {
             let draftAttachments = try await draft.attachmentList().attachments().get()
-            let dispositions = draftAttachments.map(\.attachment.disposition)
-            let inlineCount = dispositions.filter { $0 == .inline }.count
-            let attachmentCount = dispositions.filter { $0 == .attachment }.count
+            let inlineCount = draftAttachments.count(where: { $0.attachment.disposition == .inline })
+            let attachmentCount = draftAttachments.count(where: { $0.attachment.disposition == .attachment })
             AppLogger.log(message: "Attachments update: inline: \(inlineCount), attachment: \(attachmentCount)", category: .composer)
             state.attachments = draftAttachments.toDraftAttachmentUIModels()
             attachmentAlertState.enqueueAlertsForFailedAttachmentUploads(attachments: draftAttachments)

--- a/Modules/InboxWebView/Sources/preProcessedHTML.swift
+++ b/Modules/InboxWebView/Sources/preProcessedHTML.swift
@@ -1,15 +1,15 @@
 import Foundation
 
+private let httpsURLRegex = try! NSRegularExpression(pattern: #"https://[^"'\s<>)]+"#, options: [])
+
 /// Processes raw HTML by replacing https:// URLs with proton-https:// scheme
 /// and extracting only filenames from full URLs.
 public func preProcessedHTML(rawHTML: String) -> String {
     // FIXME: This function should use Rust implmentation - it's only temporary solution
     var modifiedHTML = rawHTML
 
-    let httpsURLPattern = #"https://[^"'\s<>)]+"#
-    let regex = try! NSRegularExpression(pattern: httpsURLPattern, options: [])
     let nsString = modifiedHTML as NSString
-    let matches = regex.matches(in: modifiedHTML, options: [], range: NSRange(location: 0, length: nsString.length))
+    let matches = httpsURLRegex.matches(in: modifiedHTML, options: [], range: NSRange(location: 0, length: nsString.length))
 
     for match in matches.reversed() {
         let urlRange = match.range(at: 0)


### PR DESCRIPTION
- Hoist NSRegularExpression, JSONEncoder, and DateFormatter instances to module scope so they are not re-created on every call.
- Replace filter().count, filter().isEmpty, and count > 0 patterns with count(where:), contains(where:), and !isEmpty respectively to avoid allocating intermediate arrays on hot paths (recipient field input, sidebar selection, mailbox list cell rendering, composer attachment counting).